### PR TITLE
Fix: Duplicate Scores

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,8 +20,6 @@ if (currentGame.fetchCurrentGame().gameId) {
   enterGamePopup(popupContainer);
 }
 
-window.addEventListener('load', () => {
-  if (localStorage.getItem('games') === null) {
-    enterGamePopup(popupContainer);
-  }
-});
+if (localStorage.getItem('games') === null) {
+  enterGamePopup(popupContainer);
+}

--- a/src/modules/events.js
+++ b/src/modules/events.js
@@ -96,7 +96,6 @@ const setHomeGame = () => {
     const game = gamesData.fetchGames()[0];
     currentGame.setCurrentGame(game.gameId);
     displayedGame.innerHTML = game.gameName;
-    loadScores(scoresContainer, recentScores);
   }
 
   if (gamesData.fetchGames().length === 0) {


### PR DESCRIPTION
In this pull request, I removed redundant code that was duplicating scores when:

1. The page was refreshed while there is one game in the games list.
2. User clicked the `Home` button while there is one game in the games list.